### PR TITLE
Adding a rough MVP with some user configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # Footline
-A SwiftUI View for adding a little fun and interactive footling/footer to your app
+A SwiftUI View for adding a little fun and interactive footline/footer to your app
+
+## Contents
+
+- [Add the Package](#package)
+- [Basic Usage](#basic-usage)
+
+## Package
+
+### For Xcode Projects
+
+File > Swift Packages > Add Package Dependency: https://github.com/JohnBehnke/Footline
+
+### For Swift Packages
+
+Add a dependency in your your `Package.swift`
+
+```swift
+.package(url: "https://github.com/JohnBehnke/Footline.git", from: "1.0.0"),
+```
+
+## Basic Usage
+
+Just import Footline and add the Footline view whereever you please.
+
+```swift
+import Footline
+...
+Footline()
+```
+
+Footline can take 5 possible parameters:
+
+1. `appName`
+2. `releaseVersion`
+3. `buildNumber`
+4. `locationName`
+5. `symbolName`
+
+They are used in the following format:
+
+`appName` `releaseVersion` (`buildNumber`)
+Made in `locationName` with `symbolName`
+
+By default, `appName`, `releaseVersion`, and `buildNumber` will be read from the app's Bundle, so they should refect those values based on the app you added Footline too.
+
+*Note*: `symbolName` **NEEDS** to be a valid SFSymbol, otherwise nothing will render.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A SwiftUI View for adding a little fun and interactive footline/footer to your a
 
 - [Add the Package](#package)
 - [Basic Usage](#basic-usage)
+- [Preview](#preview)
 
 ## Package
 
@@ -39,10 +40,14 @@ Footline can take 5 possible parameters:
 5. `symbolName`
 
 They are used in the following format:
-
-`appName` `releaseVersion` (`buildNumber`)
-Made in `locationName` with `symbolName`
+```
+appName releaseVersion (buildNumber)
+Made in locationName with symbolName
+```
 
 By default, `appName`, `releaseVersion`, and `buildNumber` will be read from the app's Bundle, so they should refect those values based on the app you added Footline too.
 
 *Note*: `symbolName` **NEEDS** to be a valid SFSymbol, otherwise nothing will render.
+
+## Preview
+![Footline_Demo](https://github.com/JohnBehnke/Footline/assets/5631869/b24e24ab-b97d-440a-a8d7-881e6515024a)

--- a/Sources/Footline/Bundle+AppInformation.swift
+++ b/Sources/Footline/Bundle+AppInformation.swift
@@ -1,0 +1,20 @@
+//
+//  Bundle+AppInformation.swift
+//  
+//
+//  Created by John Behnke on 8/5/23.
+//
+
+import Foundation
+
+internal extension Bundle {
+  var releaseVersionNumber: String {
+    return infoDictionary?["CFBundleShortVersionString"] as? String ?? "20XX.YY"
+  }
+  var buildVersionNumber: String {
+    return infoDictionary?["CFBundleVersion"] as? String ?? "-1"
+  }
+  var appName: String {
+    infoDictionary?["CFBundleName"] as? String ?? "My App"
+  }
+}

--- a/Sources/Footline/Footline.swift
+++ b/Sources/Footline/Footline.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+public struct Footline: View {
+    @State private var isPressed: Bool = false
+    @State private var numberOfPresses: Int = 0
+    @State private var symbolShadowColor: Color = .red
+    @State private var symbolForegroundGradient: LinearGradient =
+    LinearGradient(
+        colors: [.red, .pink],
+        startPoint: .top, endPoint: .bottom
+    )
+    
+    let symbolFillGradients: [LinearGradient] = [
+        LinearGradient(colors: [.blue, .teal], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.orange, .yellow], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.green, .blue], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.pink, .orange], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.indigo, .blue], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.mint, .teal], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.purple, .red], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.purple, .pink], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.blue, .mint], startPoint: .top, endPoint: .bottom),
+        LinearGradient(colors: [.red, .pink], startPoint: .top, endPoint: .bottom)
+    ]
+    let symbolShadowColors: [Color] = [
+        .blue,
+        .orange,
+        .green,
+        .pink,
+        .indigo,
+        .mint,
+        .purple,
+        .purple,
+        .blue,
+        .red
+    ]
+    
+    let hapticsGenerator = UINotificationFeedbackGenerator()
+    
+    var appName: String
+    var releaseVersion: String
+    var buildVersion: String
+    var locationName: String
+    var symbolName: String
+    
+    init(
+        appName: String = Bundle.main.appName,
+        releaseVersion: String = Bundle.main.releaseVersionNumber,
+        buildVersion: String = Bundle.main.buildVersionNumber,
+        locationName: String = "Connecticut",
+        symbolName: String = "heart.fill"
+    ) {
+        self.appName = appName
+        self.releaseVersion = releaseVersion
+        self.buildVersion = buildVersion
+        self.locationName = locationName
+        self.symbolName = symbolName
+    }
+    
+    public var body: some View {
+        footerText
+            .padding()
+            .foregroundColor(.gray)
+            .font(.caption)
+    }
+    
+    var footerText: some View {
+        VStack {
+            Text("\(self.appName) \(self.releaseVersion) (\(self.buildVersion))")
+            HStack(alignment: .center, spacing: 2) {
+                Text("Made in ") + Text(self.locationName).bold() + Text(" with")
+                Image(systemName: symbolName)
+                    .font(.caption2)
+                    .shadow(color: self.symbolShadowColor, radius: self.isPressed ? 3 : 1)
+                    .foregroundStyle(self.symbolForegroundGradient)
+                    .scaleEffect(self.isPressed ? 0.75 : 1.0)
+                    .rotationEffect(self.isPressed ? .degrees(numberOfPresses.isMultiple(of: 2) ? 10 : -10) : .degrees(0))
+                    .animation(.spring(response: 0.2, dampingFraction: 0.1), value: self.isPressed)
+                
+            }
+            .onTapGesture {
+                self.hapticsGenerator.notificationOccurred(.success)
+                self.symbolForegroundGradient = symbolFillGradients[numberOfPresses % symbolFillGradients.count]
+                self.symbolShadowColor = symbolShadowColors[numberOfPresses % symbolShadowColors.count]
+                self.numberOfPresses += 1
+                self.isPressed.toggle()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    self.isPressed.toggle()
+                }
+            }
+        }
+    }
+}
+
+
+struct AppFooter_Previews: PreviewProvider {
+    static var previews: some View {
+        Footline(
+            appName: "Footline",
+            releaseVersion: "1.0.0",
+            buildVersion: "1",
+            locationName: "The Matrix"
+        )
+        .frame(height: 500)
+    }
+}

--- a/Sources/Footline/Footline.swift
+++ b/Sources/Footline/Footline.swift
@@ -25,7 +25,6 @@ public struct Footline: View {
         LinearGradient(colors: [.indigo, .blue], startPoint: .top, endPoint: .bottom),
         LinearGradient(colors: [.mint, .teal], startPoint: .top, endPoint: .bottom),
         LinearGradient(colors: [.purple, .red], startPoint: .top, endPoint: .bottom),
-        LinearGradient(colors: [.purple, .pink], startPoint: .top, endPoint: .bottom),
         LinearGradient(colors: [.blue, .mint], startPoint: .top, endPoint: .bottom),
         LinearGradient(colors: [.red, .pink], startPoint: .top, endPoint: .bottom)
     ]
@@ -36,7 +35,6 @@ public struct Footline: View {
         .pink,
         .indigo,
         .mint,
-        .purple,
         .purple,
         .blue,
         .red
@@ -65,10 +63,14 @@ public struct Footline: View {
     }
     
     public var body: some View {
-        footerText
-            .padding()
-            .foregroundColor(.gray)
-            .font(.caption)
+        HStack {
+            Spacer()
+            footerText
+                .padding()
+                .foregroundColor(.gray)
+                .font(.caption)
+            Spacer()
+        }
     }
     
     var footerText: some View {
@@ -108,6 +110,5 @@ struct AppFooter_Previews: PreviewProvider {
             buildVersion: "1",
             locationName: "The Matrix"
         )
-        .frame(height: 500)
     }
 }

--- a/Sources/Footline/Footline.swift
+++ b/Sources/Footline/Footline.swift
@@ -1,3 +1,10 @@
+//
+//  Footline.swift
+//
+//
+//  Created by John Behnke on 8/5/23.
+//
+
 import SwiftUI
 
 public struct Footline: View {

--- a/Tests/FootlineTests/FootlineTests.swift
+++ b/Tests/FootlineTests/FootlineTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Footline
+
+final class FootlineTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+//        XCTAssertEqual(Footline().text, "Hello, World!")
+    }
+}


### PR DESCRIPTION
Version 1 of Footline. This allows the user to:

- Manually set the app name
- Manually set the release version
- Manually set the build version
- Manually set the location
- Manually set the symbol used at the end of the bottom line

For each of these properties, it has "sane" (at least for my personal use) defaults.